### PR TITLE
ユーザー登録機能の実装

### DIFF
--- a/app/assets/stylesheets/modules/_users.scss
+++ b/app/assets/stylesheets/modules/_users.scss
@@ -1,9 +1,6 @@
 * {
   box-sizing: border-box;
 }
-.label{
-  font-weight: 600;
-}
 
 .Single-container{
   position: relative;
@@ -62,6 +59,7 @@
       margin: 0 auto;
       background-color: white;
       &__container{
+        font-weight: bold;
         font-size: 22px;
         padding: 32px;
         text-align: center;
@@ -69,60 +67,61 @@
       } 
       .Form-container{
         padding: 24px 16px 40px;
-        .Form{
+        .new_user{
           max-width: 343px;
           margin: 0 auto;
-          &__group{
-            margin: 24px 0 0;
-            .form-require{
-              margin: 0 0 0 8px;
-              padding: 2px 4px;
-              background: #3CCACE;
-              border-radius: 2px;
-              color: #fff;
-              font-size: 12px;
+          .FormField{
+            margin: 10px 0 0;
+            &__label--normal{
+              font-weight: 600;
+              .form-require{
+                margin: 0 0 0 8px;
+                padding: 2px 4px;
+                background: #3CCACE;
+                border-radius: 2px;
+                color: #fff;
+                font-size: 12px;
+              }
+              .form-enquire{
+                margin: 0 0 0 8px;
+                padding: 2px 4px;
+                background: #ccc;
+                border-radius: 2px;
+                color: #fff;
+                font-size: 12px;
+              }
             }
-            .form-enquire{
-              margin: 0 0 0 8px;
-              padding: 2px 4px;
-              background: #ccc;
-              border-radius: 2px;
-              color: #fff;
-              font-size: 12px;
+            &__input--normal{
+              input{
+                width: 100%;
+                margin: 8px 0 8px 0;
+                height: 48px;
+                padding: 10px 16px 8px;
+                border-radius: 4px;
+                border: 1px solid #ccc;
+                background: #fff;
+                line-height: 1.5;
+                font-size: 16px;
+              }
+              select{
+                width: 100%;
+                margin: 8px 0 8px 0;
+                height: 48px;
+                padding: 10px 16px 8px;
+                border-radius: 4px;
+                border: 1px solid #ccc;
+                background: #fff;
+                line-height: 1.5;
+                font-size: 16px;
+              }
             }
-            .input-default{
-              width: 100%;
-              margin: 8px 0 8px 0;
-              height: 48px;
-              padding: 10px 16px 8px;
-              border-radius: 4px;
-              border: 1px solid #ccc;
-              background: #fff;
-              line-height: 1.5;
-              font-size: 16px;
-            }
-            .form-info-text{
-              margin: 8px 0 0;
-              line-height: 1.5;
-              color: #888;
-            }
-            .text-left{
-              font-size: 16px;
-            }
-            .l-single-text{
-              margin: 8px 0 0;
-            }
-            .form-name{
-              display: flex;
-              justify-content: space-between;
-              margin: 8px 0 8px 0;
-              .input-default-half{
+            .FormField-half{
+              input{
+                margin-top: 8px;
                 width: calc(50% - 6px);
                 height: 48px;
                 padding: 10px 16px 8px;
                 border: 1px solid #ccc;
-                background: #fff;
-                line-height: 1.5;
                 font-size: 16px;
               }
             }
@@ -133,9 +132,9 @@
               .select-wrap{
                 width: 76px;
                 height: 30px;
-                select{
+                .select-default{
                   height: 48px;
-                  width: 80px;
+                  width: 85px;
                   border: 1px solid #ccc;
                   padding: 0 10px;
                 }
@@ -148,7 +147,8 @@
               color: #888;
             }
           }
-          &__complete{
+          .Form__complete{
+            line-height: 2em;
             padding-bottom: 40px;
             font-size: 16px;
             display: flex;
@@ -159,7 +159,7 @@
           display: flex;
           justify-content: center;
           margin-top: 10px;
-          button{
+          .btn-default{
             background: #3CCACE;
             border: 1px solid #3CCACE;
             color: #fff;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,14 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth, if: :production?
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    added_attrs = [:family_name, :first_name, :family_name_kana, :first_name_kana, :year, :month, :day]
+    devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
+    devise_parameter_sanitizer.permit :account_update, keys: added_attrs
+  end 
 
   private
 

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  def new
+    @user = User.new
+  end
+
+  # POST /resource
+  def create
+    @user = User.new(sign_up_params)
+    unless @user.valid?
+      flash.now[:alert] = @user.errors.full_messages
+      render :new and return
+    end
+    session["devise.regist_data"] = {user: @user.attributes}
+    session["devise.regist_data"][:user]["password"] = params[:user][:password]
+    @address = @user.build_address
+    render :new_address
+  end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  def create_address
+    @user = User.new(session["devise.regist_data"]["user"])
+    @address = Address.new(address_params)
+    unless @address.valid?
+      flash.now[:alert] = @address.errors.full_messages
+      render :new_address and return
+    end
+    @user.build_address(@address.attributes)
+    @user.save
+    session["devise.regist_data"]["user"].clear
+    sign_in(:user, @user)
+  end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  protected
+
+  def address_params
+    params.require(:address).permit(:for_family_name, :for_first_name, :for_family_name_kana, :for_first_name_kana, :postcode, :region_id, :city, :city_number, :remarks)
+  end
+  
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,7 @@
+class Address < ApplicationRecord
+  belongs_to :user, optional: true
+  validates :for_family_name, :for_first_name, :for_family_name_kana, :for_first_name_kana, :postcode, :city, :city_number, :remarks, presence: true
+
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :region
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,13 @@
+class User < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable
+
+  validates :name, :email, :family_name, :first_name, :family_name_kana, :first_name_kana, presence: true
+  validates :name, :email, uniqueness: true
+  has_one :address
+
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :region
+end

--- a/app/views/devise/_users_footer.html.haml
+++ b/app/views/devise/_users_footer.html.haml
@@ -1,0 +1,5 @@
+%footer.single-footer
+  .single-footer-logo
+    = link_to image_tag("/material/logo/logo-white.png", class:"logo-white"), "root_path"
+  .small 
+    .small-font © FURIMA

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,0 +1,10 @@
+%h2 Resend confirmation instructions
+= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+  = render "devise/shared/error_messages", resource: resource
+  .field
+    = f.label :email
+    %br/
+    = f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email)
+  .actions
+    = f.submit "Resend confirmation instructions"
+= render "devise/shared/links"

--- a/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -1,0 +1,4 @@
+%p
+  Welcome #{@email}!
+%p You can confirm your account email through the link below:
+%p= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token)

--- a/app/views/devise/mailer/email_changed.html.haml
+++ b/app/views/devise/mailer/email_changed.html.haml
@@ -1,0 +1,8 @@
+%p
+  Hello #{@email}!
+- if @resource.try(:unconfirmed_email?)
+  %p
+    We're contacting you to notify you that your email is being changed to #{@resource.unconfirmed_email}.
+- else
+  %p
+    We're contacting you to notify you that your email has been changed to #{@resource.email}.

--- a/app/views/devise/mailer/password_change.html.haml
+++ b/app/views/devise/mailer/password_change.html.haml
@@ -1,0 +1,3 @@
+%p
+  Hello #{@resource.email}!
+%p We're contacting you to notify you that your password has been changed.

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -1,0 +1,6 @@
+%p
+  Hello #{@resource.email}!
+%p Someone has requested a link to change your password. You can do this through the link below.
+%p= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token)
+%p If you didn't request this, please ignore this email.
+%p Your password won't change until you access the link above and create a new one.

--- a/app/views/devise/mailer/unlock_instructions.html.haml
+++ b/app/views/devise/mailer/unlock_instructions.html.haml
@@ -1,0 +1,5 @@
+%p
+  Hello #{@resource.email}!
+%p Your account has been locked due to an excessive number of unsuccessful sign in attempts.
+%p Click the link below to unlock your account:
+%p= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token)

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,0 +1,19 @@
+%h2 Change your password
+= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+  = render "devise/shared/error_messages", resource: resource
+  = f.hidden_field :reset_password_token
+  .field
+    = f.label :password, "New password"
+    %br/
+    - if @minimum_password_length
+      %em
+        (#{@minimum_password_length} characters minimum)
+      %br/
+    = f.password_field :password, autofocus: true, autocomplete: "new-password"
+  .field
+    = f.label :password_confirmation, "Confirm new password"
+    %br/
+    = f.password_field :password_confirmation, autocomplete: "new-password"
+  .actions
+    = f.submit "Change my password"
+= render "devise/shared/links"

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,0 +1,10 @@
+%h2 Forgot your password?
+= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+  = render "devise/shared/error_messages", resource: resource
+  .field
+    = f.label :email
+    %br/
+    = f.email_field :email, autofocus: true, autocomplete: "email"
+  .actions
+    = f.submit "Send me reset password instructions"
+= render "devise/shared/links"

--- a/app/views/devise/registrations/create_address.html.haml
+++ b/app/views/devise/registrations/create_address.html.haml
@@ -1,0 +1,27 @@
+.Single-container
+  .Single-header
+    = image_tag("/material/logo/logo.png", {class: "logo"})
+    %nav.Signup-bar
+      %ol.clearfix
+        %li.active
+          会員情報
+          .progress-status
+        %li.active
+          商品送付先住所情報
+          .progress-status
+        %li.active
+          完了
+          .progress-status
+  .Single
+    .Single__main
+      .Single__main__container 会員登録完了
+      .Form-container
+        .new_user
+          .Form__complete
+            ありがとうございます。
+            %br
+            会員登録が完了しました。
+        .l-single-content
+          = link_to("トップページ", root_path, {class: "nav-link"})
+        = image_tag("/material/pict/bg-mainVisual-pict_pc.jpg", {class: "image"})
+  = render "users_footer"

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,0 +1,36 @@
+%h2
+  Edit #{resource_name.to_s.humanize}
+= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+  = render "devise/shared/error_messages", resource: resource
+  .field
+    = f.label :email
+    %br/
+    = f.email_field :email, autofocus: true, autocomplete: "email"
+  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+    %div
+      Currently waiting confirmation for: #{resource.unconfirmed_email}
+  .field
+    = f.label :password
+    %i (leave blank if you don't want to change it)
+    %br/
+    = f.password_field :password, autocomplete: "new-password"
+    - if @minimum_password_length
+      %br/
+      %em
+        = @minimum_password_length
+        characters minimum
+  .field
+    = f.label :password_confirmation
+    %br/
+    = f.password_field :password_confirmation, autocomplete: "new-password"
+  .field
+    = f.label :current_password
+    %i (we need your current password to confirm your changes)
+    %br/
+    = f.password_field :current_password, autocomplete: "current-password"
+  .actions
+    = f.submit "Update"
+%h3 Cancel my account
+%p
+  Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
+= link_to "Back", :back

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,0 +1,87 @@
+.Single-container
+  .Single-header
+    = image_tag("/material/logo/logo.png", {class: "logo"})
+    %nav.Signup-bar
+      %ol.clearfix
+        %li.active
+          会員情報
+          .progress-status
+        %li.active-none
+          商品送付先住所情報
+          .progress-status-none
+        %li.active-none
+          完了
+          .progress-status-none
+  .Single
+    .Single__main
+      .Single__main__container 会員情報入力
+      .Form-container
+        = form_for(@user, url: user_registration_path) do |f|
+          = render "devise/shared/error_messages", resource: @user
+          .FormField
+            .FormField__label--normal
+              = f.label :ニックネーム
+              %span.form-require 必須
+            .FormField__input--normal
+              = f.text_field :name, autofocus: true, placeholder: "例) フリマ太郎"
+          .FormField
+            .FormField__label--normal
+              = f.label :メールアドレス
+              %span.form-require 必須
+            .FormField__input--normal
+              = f.email_field :email, placeholder: "PC・携帯どちらでも可"
+          .FormField
+            .FormField__label--normal
+              = f.label :パスワード
+              %span.form-require 必須
+            .FormField__input--normal
+              = f.password_field :password, autocomplete: "off", placeholder: "7文字以上の半角英数字"
+          .FormField
+            .FormField__label--normal
+              = f.label :パスワード確認
+              %span.form-require 必須
+            .FormField__input--normal
+              = f.password_field :password_confirmation, autocomplete: "off", placeholder: "7文字以上の半角英数字"
+            %p.form-info-text
+              ※ パスワードは7文字以上
+          .FormField
+            %h3.text-left 本人確認
+            %p.l-single-text
+              安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
+          .FormField
+            .FormField__label--normal
+              = f.label :お名前
+              %span.form-require 必須
+            .FormField-half
+              = f.text_field :family_name, placeholder: "例) 山田"
+              = f.text_field :first_name, placeholder: "例) 太郎"
+          .FormField
+            .FormField__label--normal
+              = f.label :お名前カナ
+              %span.form-require 必須
+            .FormField-half
+              = f.text_field :family_name_kana, placeholder: "例) ヤマダ"
+              = f.text_field :first_name_kana, placeholder: "例) タロウ"
+          .FormField
+            .FormField__label--normal
+              = f.label :生年月日
+              %span.form-require 必須
+            .birthday-select
+              .select-wrap
+                %i.icon-arrow-bottom
+                = f.text_field :year, placeholder: "例) 2020", class: "select-default"
+              %span 年
+              .select-wrap
+                %i.icon-arrow-bottom
+                = f.text_field :month, placeholder: "例) 01", class: "select-default"
+              %span 月
+              .select-wrap
+                %i.icon-arrow-bottom
+                = f.text_field :day, placeholder: "例) 11", class: "select-default"
+              %span 日
+            %br
+              .has-error-text ※ 本人情報は正しく入力してください。
+            %input{name: "birthday", type: "hidden", value: ""}
+          .l-single-content
+            = f.submit "次へ進む", class: 'btn-default'
+  = render "users_footer"

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -1,0 +1,75 @@
+.Single-container
+  .Single-header
+    = image_tag("/material/logo/logo.png", {class: "logo"})
+    %nav.Signup-bar
+      %ol.clearfix
+        %li.active
+          会員情報
+          .progress-status
+        %li.active
+          商品送付先住所情報
+          .progress-status
+        %li.active-none
+          完了
+          .progress-status-none
+  .Single
+    .Single__main
+      .Single__main__container 発送元・お届け先住所入力
+      .Form-container
+        .new_user
+        = form_for(@address, html: {class: 'new_user'}) do |f|
+          = render "devise/shared/error_messages", resource: @address
+          .FormField
+            .FormField__label--normal
+              = f.label :お名前
+              %span.form-require 必須
+            .FormField-half
+              = f.text_field :for_family_name, placeholder: "例) 山田"
+              = f.text_field :for_first_name, placeholder: "例) 太郎"
+          .FormField
+            .FormField__label--normal
+              = f.label :お名前カナ
+              %span.form-require 必須
+            .FormField-half
+              = f.text_field :for_family_name_kana, placeholder: "例) ヤマダ"
+              = f.text_field :for_first_name_kana, placeholder: "例) タロウ"
+          .FormField
+            .FormField__label--normal
+              = f.label :郵便番号
+              %span.form-require 必須
+            .FormField__input--normal
+              = f.text_field :postcode, placeholder: "例) 123-4567"
+          .FormField
+            .FormField__label--normal
+              = f.label :都道府県
+              %span.form-require 必須
+            .FormField__input--normal
+              = f.collection_select :region_id, Region.all, :id, :name, class: "select"
+          .FormField
+            .FormField__label--normal
+              = f.label :市区町村
+              %span.form-require 必須
+            .FormField__input--normal
+              = f.text_field :city, placeholder: "例) 横浜市緑区"
+          .FormField
+            .FormField__label--normal
+              = f.label :番地
+              %span.form-require 必須
+            .FormField__input--normal
+              = f.text_field :city_number, placeholder: "例) 青山1-1-1"
+          .FormField
+            .FormField__label--normal
+              = f.label :建物名
+              %span.form-require 必須
+            .FormField__input--normal
+              = f.text_field :remarks, placeholder: "例) 柳ビル103"
+          .FormField
+            .FormField__label--normal
+              = f.label :電話
+              %span.form-require 必須
+            .FormField__input--normal
+              = f.text_field :phone_number, placeholder: "例) 09012345678"
+            .has-error-text ※ 本人情報は正しく入力してください。
+          .l-single-content
+            = f.submit "登録する", class: 'btn-default'
+  = render "users_footer"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,0 +1,29 @@
+.Single-container
+  .Single-header
+    = image_tag("/material/logo/logo.png", {class: "logo"})
+  .Single
+    .Single__main
+      .Single__main__container ログイン
+      .Form-container
+        = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+          .FormField
+            .FormField__label--normal
+              = f.label :メールアドレス
+              %span.form-require 必須
+            .FormField__input--normal
+              = f.email_field :email, autofocus: true, autocomplete: "email"
+          .FormField
+            .FormField__label--normal
+              = f.label :パスワード
+              %span.form-require 必須
+            .FormField__input--normal
+              = f.password_field :password, autocomplete: "current-password"
+          .FormField
+          - if devise_mapping.rememberable?
+            .field
+              = f.check_box :remember_me
+              = f.label :remember_me
+            = render "devise/shared/links"
+          .l-single-content
+            = f.submit "ログイン", class: 'btn-default'
+  = render "users_footer"

--- a/app/views/devise/shared/_error_messages.html.haml
+++ b/app/views/devise/shared/_error_messages.html.haml
@@ -1,0 +1,9 @@
+- if resource.errors.any?
+  #error_explanation
+    %h2
+      = I18n.t("errors.messages.not_saved",                 |
+        count: resource.errors.count,                       |
+        resource: resource.class.model_name.human.downcase) |
+    %ul
+      - resource.errors.full_messages.each do |message|
+        %li= message

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,0 +1,19 @@
+- if controller_name != 'sessions'
+  = link_to "Log in", new_session_path(resource_name)
+  %br/
+- if devise_mapping.registerable? && controller_name != 'registrations'
+  = link_to "Sign up", new_registration_path(resource_name)
+  %br/
+- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
+  = link_to "Forgot your password?", new_password_path(resource_name)
+  %br/
+- if devise_mapping.confirmable? && controller_name != 'confirmations'
+  = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
+  %br/
+- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
+  = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
+  %br/
+- if devise_mapping.omniauthable?
+  - resource_class.omniauth_providers.each do |provider|
+    = link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider)
+    %br/

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -1,0 +1,10 @@
+%h2 Resend unlock instructions
+= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
+  = render "devise/shared/error_messages", resource: resource
+  .field
+    = f.label :email
+    %br/
+    = f.email_field :email, autofocus: true, autocomplete: "email"
+  .actions
+    = f.submit "Resend unlock instructions"
+= render "devise/shared/links"

--- a/app/views/products/_topbar.html.haml
+++ b/app/views/products/_topbar.html.haml
@@ -14,7 +14,8 @@
         %li.topbar__lists--left
           = link_to "ブランド", "#", class: "top-brand"
       .topbar__bottom--right
-        = link_to "#", class: "top-login" do
-          ログイン
-        = link_to "#", class: "top-newResister" do
-          新規登録
+        - if user_signed_in?
+          = link_to "ログアウト", destroy_user_session_path, method: :delete, class: "top-newResister"
+        - else
+          = link_to "ログイン", new_user_session_path, class: "top-login"
+          = link_to "新規登録", new_user_registration_path, class: "top-newResister"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,311 @@
+# frozen_string_literal: true
+
+# Assuming you have not yet modified this file, each configuration option below
+# is set to its default value. Note that some are commented out while others
+# are not: uncommented lines are intended to protect your configuration from
+# breaking changes in upgrades (i.e., in the event that future versions of
+# Devise change the default values for those options).
+#
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = '8a1149e373008277c281176302f7d3329f2f81e401032ecd7f47c4b16fa762859f17122b8a7ab6f2d0dca1aacd85d6aaf4efdb0cbcf24c84c1a8bdacc03933ed'
+
+  # ==> Controller configuration
+  # Configure the parent class to the devise controllers.
+  # config.parent_controller = 'DeviseController'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [:email]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [:email]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication.
+  # For API-only applications to support authentication "out-of-the-box", you will likely want to
+  # enable this with :database unless you are using a custom strategy.
+  # The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # When false, Devise will not attempt to reload routes on eager load.
+  # This can reduce the time taken to boot the app but if your application
+  # requires the Devise mappings to be loaded during boot time the application
+  # won't boot properly.
+  # config.reload_routes = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 12. If
+  # using other algorithms, it sets how many times you want the password to be hashed.
+  # The number of stretches used for generating the hashed password are stored
+  # with the hashed password. This allows you to change the stretches without
+  # invalidating existing passwords.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # algorithm), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 12
+
+  # Set up a pepper to generate the hashed password.
+  # config.pepper = 'f30d03e762687be929bfcc2a2ec15cfc50181270cd890956603848412a8316b4deff695bcb05ec97a8770c2cf2ab19e4d774fe731eb0b34fde76eb1ec6833558'
+
+  # Send a notification to the original email when the user's email is changed.
+  # config.send_email_changed_notification = false
+
+  # Send a notification email when the user's password is changed.
+  # config.send_password_change_notification = false
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day.
+  # You can also set it to nil, which will allow the user to access the website
+  # without confirming their account.
+  # Default is 0.days, meaning the user cannot access the website without
+  # confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 6..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
+  # You can use :sha1, :sha512 or algorithms from others authentication tools as
+  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
+  # for default behavior) and :restful_authentication_sha1 (then you should set
+  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html, should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+
+  # ==> Turbolinks configuration
+  # If your app is using Turbolinks, Turbolinks::Controller needs to be included to make redirection work correctly:
+  #
+  # ActiveSupport.on_load(:devise_failure_app) do
+  #   include Turbolinks::Controller
+  # end
+
+  # ==> Configuration for :registerable
+
+  # When set to false, does not sign a user in automatically after their password is
+  # changed. Defaults to true, so a user is signed in automatically after changing a password.
+  # config.sign_in_after_change_password = true
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,65 @@
+# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again"
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,15 +15,3 @@ Rails.application.routes.draw do
   end
   resources :creditcards, only: [:show, :new]
 end
-
-  devise_for :users, controllers: {
-    registrations: 'users/registrations'
-  }
-  devise_scope :user do
-    get 'addresses', to: 'users/registrations#new_address'
-    post 'addresses', to: 'users/registrations#create_address'
-  end
-
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  resources :products, only: [:index, :new, :create, :show]
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,21 @@
 Rails.application.routes.draw do
+  root 'products#index'
+  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  resources :products, only: [:index, :new, :create, :show] do
+    resources :orders, only: [:new] do
+      collection do
+        get :create
+      end # 一時的にcreateをcollectionでビュー確認しています。
+    end
+  end
+  resources :users, only: [:new, :edit, :update, :show, :create] do
+    collection do 
+      get :logout
+    end
+  end
+  resources :creditcards, only: [:show, :new]
+end
+
   devise_for :users, controllers: {
     registrations: 'users/registrations'
   }
@@ -7,8 +24,6 @@ Rails.application.routes.draw do
     post 'addresses', to: 'users/registrations#create_address'
   end
 
-  root 'products#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :products, only: [:index, :new, :create, :show]
-  resources :users, only: [:new, :edit, :update, :show, :create, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,14 @@
 Rails.application.routes.draw do
+  devise_for :users, controllers: {
+    registrations: 'users/registrations'
+  }
+  devise_scope :user do
+    get 'addresses', to: 'users/registrations#new_address'
+    post 'addresses', to: 'users/registrations#create_address'
+  end
+
   root 'products#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :products, only: [:index, :new, :create, :show]
-  resources :users, only: [:new, :edit, :update, :show, :create]
+  resources :users, only: [:new, :edit, :update, :show, :create, :destroy]
 end

--- a/db/migrate/20200708032407_devise_create_users.rb
+++ b/db/migrate/20200708032407_devise_create_users.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class DeviseCreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users do |t|
+      ## Database authenticatable
+      t.string :name,               null: false
+      t.string :email,              null: false
+      t.string :encrypted_password, null: false
+      t.string :family_name,        null: false
+      t.string :first_name,         null: false
+      t.string :family_name_kana,   null: false
+      t.string :first_name_kana,    null: false
+      t.integer :year,              null: false
+      t.integer :month,             null: false
+      t.integer :day,               null: false
+
+      t.integer :region_id
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.string   :current_sign_in_ip
+      # t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+
+      t.timestamps null: true
+    end
+
+    add_index :users, :name,                 unique: true
+    add_index :users, :email,                unique: true
+    add_index :users, :reset_password_token, unique: true
+    # add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,         unique: true
+  end
+end

--- a/db/migrate/20200708040714_create_addresses.rb
+++ b/db/migrate/20200708040714_create_addresses.rb
@@ -1,0 +1,18 @@
+class CreateAddresses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :addresses do |t|
+      t.string :for_family_name,      null: false
+      t.string :for_first_name,       null: false
+      t.string :for_family_name_kana, null: false
+      t.string :for_first_name_kana,  null: false
+      t.string :postcode,             null: false
+      t.integer :region_id,           null: false
+      t.string :city,                 null: false
+      t.string :city_number,          null: false
+      t.string :remarks
+      t.integer :phone_number
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_07_121750) do
+ActiveRecord::Schema.define(version: 2020_07_08_040714) do
+
+  create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "for_family_name", null: false
+    t.string "for_first_name", null: false
+    t.string "for_family_name_kana", null: false
+    t.string "for_first_name_kana", null: false
+    t.string "postcode", null: false
+    t.integer "region_id", null: false
+    t.string "city", null: false
+    t.string "city_number", null: false
+    t.string "remarks"
+    t.integer "phone_number"
+    t.bigint "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_addresses_on_user_id"
+  end
 
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "src", null: false
@@ -34,5 +51,28 @@ ActiveRecord::Schema.define(version: 2020_07_07_121750) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "encrypted_password", null: false
+    t.string "family_name", null: false
+    t.string "first_name", null: false
+    t.string "family_name_kana", null: false
+    t.string "first_name_kana", null: false
+    t.integer "year", null: false
+    t.integer "month", null: false
+    t.integer "day", null: false
+    t.integer "region_id"
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["name"], name: "index_users_on_name", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  add_foreign_key "addresses", "users"
   add_foreign_key "images", "products"
 end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :address do
+    
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user do
+    
+  end
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Address, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# What
ユーザー登録機能の実装

# Why
ウィザード形式でユーザー新規登録ができるようにするため。
ログイン状態とログアウト状態に分けるため。
①ユーザー情報登録
https://gyazo.com/306bcc2661676578feeaf693e20b841d
②住所情報登録
https://gyazo.com/90c3ddf9cff7cff97248b72694c4ee0e
③登録完了
https://gyazo.com/37e454ed272d74a25a77fd32df39c62f
④ログアウト状態
https://gyazo.com/2d9ad61ff2206efe45e576e10ac84b3b